### PR TITLE
Blank lLine before statement

### DIFF
--- a/lib/component-template/Component.txt
+++ b/lib/component-template/Component.txt
@@ -17,6 +17,7 @@ export default class ##COMPONENT_NAME## extends PureComponent {
 
   render() {
     const { children } = this.props;
+    
     return (
 ==ifstyles
       <div className={s.##COMPONENT_NAME_CAMEL##}>


### PR DESCRIPTION
Added a blank line before statement because of our lint rule: https://eslint.org/docs/rules/padding-line-between-statements